### PR TITLE
Undefined constant if ActiveRecord not loaded

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,5 @@
+require 'active_record/errors'
+
 class Post
   extend ActiveModel::Naming
 


### PR DESCRIPTION
Simple fix for ActiveRecord::RecordNotFound not being defined when Rails is being used without ActiveRecord
