### PR TITLE
Add combustion development dependency.

### DIFF
--- a/postmarkdown.gemspec
+++ b/postmarkdown.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 1.0.0.beta'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'delorean', '>= 0.2'
+  s.add_development_dependency 'combustion', '~> 0.3.1'
 end


### PR DESCRIPTION
Specs weren't running without combustion declared as a development dependency.
