### PR TITLE
Generate overridden theme inside `app`

### DIFF
--- a/lib/generators/postmarkdown/override_generator.rb
+++ b/lib/generators/postmarkdown/override_generator.rb
@@ -36,7 +36,7 @@ module Postmarkdown
 
     def override_theme
       if options.theme || options.all
-        directory 'views/layouts', 'views/layouts'
+        directory 'views/layouts', 'app/views/layouts'
         if Rails.application.config.respond_to?(:assets) && Rails.application.config.assets.enabled
           directory '../vendor/assets/stylesheets', 'app/assets/stylesheets'
         else


### PR DESCRIPTION
Previously, the theme layout would be written to a `views/layouts` directory in the root of your application.
