### PR TITLE
Allow setting the specific layout name.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  layout lambda { |controller| Postmarkdown::Config.options[:use_theme] ? 'postmarkdown' : 'application' }
+  layout :choose_layout
 
   def show
     resource
@@ -33,5 +33,13 @@ class PostsController < ApplicationController
 
   def posts_per_page
     params[:count] || Postmarkdown::Config.options[:posts_per_page]
+  end
+
+  def choose_layout
+    if Postmarkdown::Config.options[:use_theme]
+      'postmarkdown'
+    else
+      Postmarkdown::Config.options[:layout]
+    end
   end
 end

--- a/lib/postmarkdown/config.rb
+++ b/lib/postmarkdown/config.rb
@@ -13,7 +13,7 @@ Postmarkdown::Config.options[:permalink_format] = :day
 
 Postmarkdown::Config.options[:posts_per_page] = 5
 
-Postmarkdown::Config.options[:use_theme] = false
+Postmarkdown::Config.options[:layout] = 'application'
 
 Postmarkdown::Config.options[:permalink_regex] = {}
 Postmarkdown::Config.options[:permalink_regex][:day]   = %r[\d{4}/\d{2}/\d{2}/[^/]+]

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,12 @@ Postmarkdown comes with minimal built-in theme for your convenience. To turn on 
 
     Postmarkdown::Config.options[:use_theme] = true
 
+## Customizing the layout
+
+By default, Postmarkdown will use your application's default layout, but if you wish to use a specific custom layout, you can set the following configuration in an initializer, as above:
+
+    Postmarkdown::Config.options[:layout] = 'layout_name'
+
 ## Customizing Routes
 
 By default Postmarkdown will setup all routes to go through the `/posts/*` path. For example:

--- a/spec/integrations/posts_spec.rb
+++ b/spec/integrations/posts_spec.rb
@@ -180,15 +180,25 @@ describe 'Post views', :type => :request do
   end
 
   context 'theme' do
-    it 'should not use the built-in layout by default' do
+    before { @original_layout = Postmarkdown::Config.options[:layout] }
+    after { Postmarkdown::Config.options[:layout] = @original_layout }
+
+    it 'should use the application layout by default' do
       visit posts_path
       page.should_not have_content('A postmarkdown blog')
     end
 
-    it 'should use the built-in layout when the global option is set' do
+    it 'should use the postmarkdown layout when using theme' do
       Postmarkdown::Config.options[:use_theme] = true
       visit posts_path
       page.should have_content('A postmarkdown blog')
+      Postmarkdown::Config.options[:use_theme] = false
+    end
+
+    it 'should use the built-in layout when the global option is set to true' do
+      Postmarkdown::Config.options[:layout] = 'custom_layout'
+      visit posts_path
+      page.should have_content('A custom layout')
     end
   end
 end

--- a/spec/internal/app/views/layouts/custom_layout.html.erb
+++ b/spec/internal/app/views/layouts/custom_layout.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>RailsApp</title>
+  <%= csrf_meta_tag %>
+</head>
+<body>
+
+<p>A custom layout</p>
+
+<%= yield %>
+
+</body>
+</html>


### PR DESCRIPTION
In an application, I might want to use an existing layout which
isn't called `application` or `postmarkdown`.
