### PR TITLE
Allow Rails helpers to be called in posts.

### DIFF
--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,0 +1,20 @@
+module PostHelper
+  class Sanitizer < HTML::WhiteListSanitizer
+    self.allowed_tags -= %w(img a)
+  end
+
+  def post_summary_html(post)
+    if post.summary.present?
+      content_tag :p, post.summary
+    else
+      html = Sanitizer.new.sanitize(post_content_html(post))
+      doc = Nokogiri::HTML.fragment(html)
+      para = doc.search('p').detect { |p| p.text.present? }
+      para.try(:to_html).try(:html_safe)
+    end
+  end
+
+  def post_content_html(post)
+    RDiscount.new(render(:inline => post.content)).to_html.html_safe
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -47,6 +47,10 @@ class Post
     metadata[:title] || slug.titleize
   end
 
+  def summary
+    metadata[:summary]
+  end
+
   def author
     metadata[:author]
   end
@@ -72,27 +76,6 @@ class Post
 
   def to_s
     "#{title.inspect} (#{slug})"
-  end
-
-  def content_html
-    RDiscount.new(content).to_html.html_safe
-  end
-
-  class Sanitizer < HTML::WhiteListSanitizer
-    self.allowed_tags -= %w(img a)
-  end
-
-  TagHelper = Class.new.extend ActionView::Helpers::TagHelper
-
-  def summary_html
-    if metadata[:summary].present?
-      TagHelper.content_tag :p, metadata[:summary]
-    else
-      html = Sanitizer.new.sanitize(content_html)
-      doc = Nokogiri::HTML.fragment(html)
-      para = doc.search('p').detect { |p| p.text.present? }
-      para.try(:to_html).try(:html_safe)
-    end
   end
 
   class << self

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -10,7 +10,7 @@
         by
         = post.author
   - if summary
-    = post.summary_html
+    = post_summary_html post
     %p.more= link_to 'Read more&hellip;'.html_safe, post
   - else
-    ~ post.content_html
+    ~ post_content_html post

--- a/app/views/posts/feed.xml.builder
+++ b/app/views/posts/feed.xml.builder
@@ -22,7 +22,7 @@ xml.feed :xmlns => 'http://www.w3.org/2005/Atom' do
 
       xml.id post_url(post)
       xml.content :type => :html, 'xml:base' => post_url(post) do
-        xml.cdata! post.content_html
+        xml.cdata! post_content_html(post)
       end
     end
   end

--- a/spec/integrations/posts_spec.rb
+++ b/spec/integrations/posts_spec.rb
@@ -141,6 +141,10 @@ describe 'Post views', :type => :request do
     it 'should preserve whitespace on code blocks' do
       page.source.should match '<pre><code>First line of code.&#x000A;  Second line of code.&#x000A;</code></pre>'
     end
+
+    it 'should allow calling Rails helpers via ERB tags' do
+      page.source.should match('<p>Paragraph created by Rails helper</p>')
+    end
   end
 
   context 'Posts#feed' do

--- a/spec/internal/app/posts/2011-05-01-full-metadata.markdown
+++ b/spec/internal/app/posts/2011-05-01-full-metadata.markdown
@@ -11,3 +11,5 @@ Second paragraph of content.
 
     First line of code.
       Second line of code.
+
+<%= content_tag :p, "Paragraph created by Rails helper" %>

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -22,12 +22,6 @@ describe Post do
     its(:date) { should == Date.parse('2011-04-01') }
     its(:title) { should == 'First Post' }
     its(:content) { should =~ /\ALorem ipsum/ }
-    its(:content_html) { should =~ /^<p>Lorem ipsum/ }
-    its(:content_html) { should =~ /^<p>Duis aute irure dolor/ }
-    its(:content_html) { should be_html_safe }
-    its(:summary_html) { should =~ /^<p>Lorem ipsum/ }
-    its(:summary_html) { should_not =~ /^<p>Duis aute irure dolor/ }
-    its(:summary_html) { should be_html_safe }
   end
 
   context 'with custom title post' do
@@ -44,16 +38,9 @@ describe Post do
     its(:email) { should == 'john.smith@example.com' }
   end
 
-  context 'with image post' do
-    subject { test_post '2011-04-28-image.markdown' }
-    its(:summary_html) { should =~ /^<p>Image description/ }
-    its(:summary_html) { should be_html_safe }
-  end
-
   context 'with custom summary post' do
     subject { test_post '2011-04-28-summary.markdown' }
-    its(:summary_html) { should == '<p>This is a custom &amp; test summary.</p>' }
-    its(:summary_html) { should be_html_safe }
+    its(:summary) { should == 'This is a custom & test summary.' }
   end
 
   context 'with alternate markdown file extension' do


### PR DESCRIPTION
The big win here is being able to call asset helpers like
`image_tag`, so that you can keep images within the asset pipeline
and be confident that they will work both in development, and
production.

For example, image URLs in the feed need to be absolute, but the
host is unlikely to be the same in development and production, so
being able to call `<%= image_tag %>` and have it respect the actual
asset host is really useful.

The default handler when rendering inline is `ERB`, and I suspect
that it's not going to be pragmatic to support whitespace-sensitive
handlers like HAML in this way, unfortunately.
