### PR TITLE
Adding time to generated post file name.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'ruby-debug19', :require => false
+gem 'timecop', :require => false
+gem 'generator_spec', :require => false

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,11 +9,16 @@ class Post
 
   attr_reader :slug
 
-  FILENAME_FORMAT = /^(\d+-\d+-\d+)-(.*)(\.[^.]+)$/
+  TIME_FORMAT = /-\d{6}/
+  DATE_FORMAT = /\d{4}-\d{2}-\d{2}(#{TIME_FORMAT})?/
+  SLUG_FORMAT = /[A-Za-z0-9\-]+/
+  EXTENSION_FORMAT = /\.[^.]+/
+
+  FILENAME_FORMAT = /^(#{DATE_FORMAT})-(#{SLUG_FORMAT})(#{EXTENSION_FORMAT})$/
 
   def initialize(path)
     @path = path
-    @date_str, @slug = File.basename(path).match(FILENAME_FORMAT).captures
+    @date_str, _, @slug = File.basename(path).match(FILENAME_FORMAT).captures
   end
 
   def to_param
@@ -98,9 +103,13 @@ class Post
   class << self
     def all
       file_extensions = Postmarkdown::Config.options[:markdown_file_extensions].join(',')
-      @@posts ||= Dir.glob(Rails.root + "app/posts/*.{#{file_extensions}}").map do |filename|
+      @@posts ||= Dir.glob("#{directory}/*.{#{file_extensions}}").map do |filename|
         Post.new filename
       end.select(&:visible?).sort_by(&:date).reverse
+    end
+
+    def directory
+      Rails.root.join('app', 'posts')
     end
 
     def where(conditions = {})

--- a/lib/generators/postmarkdown/post_generator.rb
+++ b/lib/generators/postmarkdown/post_generator.rb
@@ -6,14 +6,14 @@ module Postmarkdown
     class_option :date, :type => :string, :group => :runtime, :desc => 'Publish date for the post'
 
     def check_slug
-      unless slug =~ /^[A-Za-z0-9\-]+$/
+      unless slug =~ /^#{Post::SLUG_FORMAT}$/
         puts 'Invalid slug - valid characters include letters, digits and dashes.'
         exit
       end
     end
 
     def check_date
-      if options.date && options.date !~ /^\d{4}-\d{2}-\d{2}$/
+      if options.date && options.date !~ /^#{Post::DATE_FORMAT}$/
         puts 'Invalid date - please use the following format: YYYY-MM-DD, eg. 2011-01-01.'
         exit
       end
@@ -26,8 +26,17 @@ module Postmarkdown
     private
 
     def publish_date
-      date = options.date.present? ? Time.zone.parse(options.date) : Time.zone.now
-      date.strftime('%Y-%m-%d')
+      format = '%Y-%m-%d-%H%M%S'
+
+      if options.date.present?
+        date_string = options.date
+        date_string += '-000000' unless options.date.match(/(#{Post::TIME_FORMAT}$)/)
+        date = DateTime.strptime(date_string, format)
+      else
+        date = Time.zone.now
+      end
+
+      date.strftime(format)
     end
   end
 end

--- a/spec/lib/generators/postmarkdown/post_generator_spec.rb
+++ b/spec/lib/generators/postmarkdown/post_generator_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+module Postmarkdown
+  describe PostGenerator do
+    include GeneratorSpec::TestCase
+    destination File.expand_path('../../../../../tmp', __FILE__)
+
+    before do
+      prepare_destination
+
+      Post.stub(:directory) { File.expand_path('tmp/app/posts') }
+      Post.class_variable_set('@@posts', nil)
+    end
+
+    context 'with the slug parameter' do
+      it 'creates a file for the slug and the current date' do
+        Timecop.freeze(Time.utc(2012, 1, 1, 10, 20, 30)) do
+          run_generator %w(test-post)
+
+          Dir.glob('tmp/app/posts/*').should == ['tmp/app/posts/2012-01-01-102030-test-post.markdown']
+
+          Post.all.count.should == 1
+
+          post = Post.first
+          post.slug.should == 'test-post'
+          post.date.should == Date.parse('2012-01-01')
+          post.title.should == 'Test post'
+        end
+      end
+    end
+
+    context 'with the slug and date parameters' do
+      it 'creates a file for the slug and the given date' do
+        puts 'ran generator'
+        run_generator %w(other-post --date=2012-01-02)
+
+        Dir.glob('tmp/app/posts/*').should == ['tmp/app/posts/2012-01-02-000000-other-post.markdown']
+
+        Post.all.count.should == 1
+
+        post = Post.first
+        post.slug.should == 'other-post'
+        post.date.should == Date.parse('2012-01-02')
+        post.title.should == 'Other post'
+      end
+    end
+
+    context 'with the slug, date and time parameters' do
+      it 'creates a file for the slug and the given date' do
+        puts 'ran generator'
+        run_generator %w(other-post --date=2012-01-02-102030)
+
+        Dir.glob('tmp/app/posts/*').should == ['tmp/app/posts/2012-01-02-102030-other-post.markdown']
+
+        Post.all.count.should == 1
+
+        post = Post.first
+        post.slug.should == 'other-post'
+        post.date.should == Time.utc(2012, 01, 02, 10, 20, 30).to_date
+        post.title.should == 'Other post'
+      end
+    end
+
+    context 'with invalid slug' do
+      it 'raises a system exit exception' do
+        lambda { run_generator %w(!test-post) }.should raise_error(SystemExit)
+      end
+
+      it 'does not create the file' do
+        Dir['app/posts/*'].should be_empty
+      end
+    end
+
+    context 'with invalid date' do
+      it 'raises a system exit exception' do
+        lambda { run_generator %w(test-post --date=2012-02) }.should raise_error(SystemExit)
+      end
+
+      it 'does not create the file' do
+        Dir['app/posts/*'].should be_empty
+      end
+    end
+  end
+end

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -16,6 +16,10 @@ describe Post do
     end
   end
 
+  it 'should return the correct directory' do
+    Post.directory.should == Rails.root.join('app', 'posts')
+  end
+
   context 'with first post' do
     subject { test_post '2011-04-01-first-post.markdown' }
     its(:slug) { should == 'first-post' }
@@ -34,6 +38,14 @@ describe Post do
     subject { test_post '2015-02-13-custom-title.markdown' }
     its(:slug) { should == 'custom-title' }
     its(:date) { should == Date.parse('2015-02-13') }
+    its(:title) { should == 'This is a custom title' }
+    its(:content) { should == "Content goes here.\n" }
+  end
+
+  context 'with a custom title that also and including timestamp' do
+    subject { test_post '2012-02-13-102030-custom-title-and-timestamp.markdown' }
+    its(:slug) { should == 'custom-title-and-timestamp' }
+    its(:date) { should == Time.utc(2012, 02, 13, 10, 20, 30).to_date }
     its(:title) { should == 'This is a custom title' }
     its(:content) { should == "Content goes here.\n" }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,11 +18,21 @@ require 'capybara/rspec'
 require 'rspec/rails'
 require 'capybara/rails'
 
+require 'timecop'
+require 'generator_spec/test_case'
+Dir[File.expand_path('lib/generators/postmarkdown/*.rb')].each { |f| require f }
+
 require 'delorean'
 
 RSpec.configure do |config|
   config.mock_with :rspec
   config.include Delorean
+  config.order = :random
+
+  config.after do
+    Timecop.return
+    FileUtils.rm_rf('spec/tmp/app/posts/.')
+  end
 end
 
 ActiveSupport::Deprecation.debug = true

--- a/spec/support/data/posts/2012-02-13-102030-custom-title-and-timestamp.markdown
+++ b/spec/support/data/posts/2012-02-13-102030-custom-title-and-timestamp.markdown
@@ -1,0 +1,5 @@
+---
+title: This is a custom title
+---
+
+Content goes here.


### PR DESCRIPTION
Posts are now be generated with a UTC time included in their filename to allow for correct time identification and also proper sorting when multiple posts exist on the same day.

The generator can be run as follows:

``` bash
rails g postmarkdown:post new-post # will generate the file app/posts/{year}-{month}-{day}-{hour}{minute}{second}-new-post.markdown
rails g postmarkdown:post new-post --date=2012-12-18 # will generate the file app/posts/2012-12-18-000000-new-post.markdown
rails g postmarkdown:post new-post --date=2012-12-18-203231 # will generate the file app/posts/2012-12-18-203231-new-post.markdown
```

Also, I had to include some additional dependencies to be able to test the `PostGenerator`.

Generated posts with a filename of `{year}-{month}-{day}-name.markdown` (from previous postmarkdown versions) are equivalent to `{year}-{month}-{day}-000000-name.markdown` 
