### PR TITLE
Fix: Allow posts with underscores in the filename

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,7 +11,7 @@ class Post
 
   TIME_FORMAT = /-\d{6}/
   DATE_FORMAT = /\d{4}-\d{2}-\d{2}(#{TIME_FORMAT})?/
-  SLUG_FORMAT = /[A-Za-z0-9\-]+/
+  SLUG_FORMAT = /[A-Za-z0-9_\-]+/
   EXTENSION_FORMAT = /\.[^.]+/
 
   FILENAME_FORMAT = /^(#{DATE_FORMAT})-(#{SLUG_FORMAT})(#{EXTENSION_FORMAT})$/

--- a/lib/generators/postmarkdown/templates/example-post.markdown
+++ b/lib/generators/postmarkdown/templates/example-post.markdown
@@ -1,5 +1,5 @@
 ---
-title: <%= slug.underscore.humanize %>
+title: <%= slug.gsub('-',' ').capitalize %>
 <%- if author = Postmarkdown::Util.git_config('user.name') -%>
 author: <%= author %>
 <%- end -%>

--- a/spec/lib/generators/postmarkdown/post_generator_spec.rb
+++ b/spec/lib/generators/postmarkdown/post_generator_spec.rb
@@ -29,6 +29,23 @@ module Postmarkdown
       end
     end
 
+    context 'with the slug parameter including an underscore' do
+      it 'creates the correct file and sets the right values' do
+        Timecop.freeze(Time.utc(2012, 1, 1, 10, 20, 30)) do
+          run_generator %w(test-post_with_underscores)
+
+          Dir.glob('tmp/app/posts/*').should == ['tmp/app/posts/2012-01-01-102030-test-post_with_underscores.markdown']
+
+          Post.all.count.should == 1
+
+          post = Post.first
+          post.slug.should == 'test-post_with_underscores'
+          post.date.should == Date.parse('2012-01-01')
+          post.title.should == 'Test post_with_underscores'
+        end
+      end
+    end
+
     context 'with the slug and date parameters' do
       it 'creates a file for the slug and the given date' do
         run_generator %w(other-post --date=2012-01-02)

--- a/spec/models/posts_spec.rb
+++ b/spec/models/posts_spec.rb
@@ -44,6 +44,11 @@ describe Post do
     its(:content) { should == "Content goes here.\n" }
   end
 
+  context 'with a custom title with underscores' do
+    subject { test_post '2012-02-12-102030-custom-title-with_underscores.markdown' }
+    its(:slug) { should == 'custom-title-with_underscores' }
+  end
+
   context 'with author' do
     subject { test_post '2011-05-01-full-metadata.markdown' }
     its(:author) { should == 'John Smith' }


### PR DESCRIPTION
I just realized while using the new version on a site that had a couple of posts with underscores in the filename that they were not working anymore. 

This is a regression I introduced when adding the timestamp functionality and went unnoticed. I fixed it and added tests to avoid this happening again.

I also changed it so that if you want to generate a post with underscores in it, they won't be removed by the generator when creating the default title.
